### PR TITLE
Filters and Array data type

### DIFF
--- a/api/cbrcycle/retrieve.py
+++ b/api/cbrcycle/retrieve.py
@@ -351,8 +351,8 @@ def getQueryFunction(projId, caseAttrib, queryValue, weight, simMetric, options)
   elif simMetric == "Feature-based":
     sim_grid = getOntoSimilarity(projId + "_ontology_" + options['name'], queryValue)
     return OntologySimilarity(caseAttrib, queryValue, weight, sim_grid)
-  elif simMetric == "Array":
-    return Array(caseAttrib, queryValue, weight)
+  elif simMetric == "Jaccard" or simMetric == "Array":  # Array was renamed to Jaccard. "Array" kept on until adequate notice is given to update existing applications.
+    return Jaccard(caseAttrib, queryValue, weight)
   elif simMetric == "Array SBERT":
     return ArraySBERT(caseAttrib, getVectorSemanticSBERTArray(queryValue), weight)
   else:
@@ -363,7 +363,7 @@ def getQueryFunction(projId, caseAttrib, queryValue, weight, simMetric, options)
 # Each similarity function returns a Painless script for Elasticsearch. 
 # Each function requires field name and set of functions-specific parameters.
 
-def Array(caseAttrib, queryValue, weight):
+def Jaccard(caseAttrib, queryValue, weight):
   """
   Returns the similarity between two arrays
   """

--- a/api/cbrcycle/retrieve.py
+++ b/api/cbrcycle/retrieve.py
@@ -9,6 +9,27 @@ import json
 import config as cfg
 
 
+def get_filter_object(filterTerm, fieldName, filterValue=None, fieldValue=None):
+  """
+  Returns a filter object that can be included in a OpenSearch query (https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html)
+  filterTerm options: None, =, >, >=, <, <=. Not None filterTerm should be accompanied with values.
+  """
+  if fieldName is not None and filterTerm is not None and filterTerm != 'None':  # check that there is a filter
+    # construct object according to filter type
+    if filterTerm == '=' and fieldValue is not None:
+      return {'term': {fieldName: fieldValue}}
+    if filterValue is not None:
+      if filterTerm == '>':  # gt
+        return {'range': {fieldName: {'gt': filterValue}}}
+      if filterTerm == '>=':  # gte
+        return {'range': {fieldName: {'gte': filterValue}}}
+      if filterTerm == '<':  # lt
+        return {'range': {fieldName: {'lt': filterValue}}}
+      if filterTerm == '<=':  # lte
+        return {'range': {fieldName: {'lte': filterValue}}}
+  return None  # no filter
+
+
 def getVector(text):
   """
   Calls an external service to get the 512 dimensional vector representation of a piece of text.

--- a/api/handler.py
+++ b/api/handler.py
@@ -808,7 +808,7 @@ def cbr_retrieve(event, context=None):
   if counter > 0:
     for entry in queryFeatures:
       field = entry['name']
-      strategy = entry.get('strategy', "Best Match")
+      strategy = entry.get('strategy', "NN value")  # NN (nearest neighbour)
       if not entry.get('unknown', False) and entry.get('value') is not None and "" != entry['value']:  # copy known values
         result['recommended'][field] = entry['value']
       else:  # use reuse strategies for unknown fields
@@ -821,10 +821,13 @@ def cbr_retrieve(event, context=None):
             result['recommended'][field] = np.mean([x[field] for x in result['bestK']])
           elif strategy == "Median":
             result['recommended'][field] = np.median([x[field] for x in result['bestK']])
-          elif strategy == "Mode":
+          elif strategy == "Mode" or strategy == "Majority":
             result['recommended'][field] = statistics.mode([x[field] for x in result['bestK']])
+          elif strategy == "Minority":
+            lst = [x[field] for x in result['bestK']]
+            result['recommended'][field] = min(set(lst), key=lst.count)
           else:
-            result['recommended'][field] = result['bestK'][0][field]  # assign value of 'Best Match'
+            result['recommended'][field] = result['bestK'][0][field]  # assign value of 'NN value'
     # generate a new random id to make (if there was an id) to make it different from existing cases
     if result['recommended'].get('id') is not None:
       result['recommended']['id'] = uuid.uuid4().hex

--- a/api/handler.py
+++ b/api/handler.py
@@ -907,6 +907,8 @@ def cbr_retain(event, context=None):
                                     root_node=attrib['options'].get('root'), similarity_method=sim_method)
 
     new_case = params['data']
+    if isinstance(new_case, str):  # new_case could be str or dict
+      new_case = json.loads(new_case)
     case_id = new_case.get('_id') # check for optional id in case description
     new_case = retrieve.add_vector_fields(proj['attributes'], new_case)  # add vectors to Semantic USE fields
 

--- a/api/handler.py
+++ b/api/handler.py
@@ -220,6 +220,7 @@ def new_project(event, context=None):
     proj['hasCasebase'] = False
 
     try:
+      print(proj)
       result = es.index(index=projects_db, body=proj, id=proj_id)
       result = {"index": result['_index'], "id": result['_id'], "result": result['result'], "project": proj}
     except:
@@ -738,10 +739,11 @@ def cbr_retrieve(event, context=None):
   start = timer()  # start timer
 
   params = json.loads(event['body'])  # parameters in request body
+  # print(params)
   queryFeatures = params.get('data')
   addExplanation = params.get('explanation')
   proj = params.get('project')
-  filter = params.get('filter', None)
+  # filter = params.get('filter', None)
   globalSim = params.get('globalSim', "Weighted Sum")  # not used as default aggregation is a weighted sum of local similarity values
 
   result = {'recommended': {}, 'bestK': []}
@@ -754,10 +756,19 @@ def cbr_retrieve(event, context=None):
 
   proj_attributes = proj['attributes']
   
-  query = {"query": {"bool": {"should": []}}}
+  query = {"query": {"bool": {"filter": [], "should": []}}}
   query["size"] = int(params.get('topk', 5))  # number of cases to retrieve, default is 5
 
-  for entry in queryFeatures:
+  for entry in queryFeatures: # add term filters (extend to include range filters for numbers and dates)
+    if entry.get('filterTerm') is not None and entry.get('filterTerm') != 'None':
+      field = entry.get('name')
+      value = entry.get('value')
+      # filter = { "term":  { field: value }}
+      filter = retrieve.get_filter_object(entry.get('filterTerm'), field, entry.get('filterValue'), value)
+      if filter is not None:
+        query["query"]["bool"]["filter"].append(filter)
+        queryAdded = True
+
     if entry.get('value') is not None and "" != entry['value'] and int(
             entry.get('weight', 1)) > 0 and entry.get('similarity') != "None":
       field = entry['name']
@@ -770,8 +781,8 @@ def cbr_retrieve(event, context=None):
       qfnc = retrieve.getQueryFunction(proj['id__'], field, value, weight, similarityType, options)
       query["query"]["bool"]["should"].append(qfnc)
 
-  if filter is not None and filter != "" and filter != {}:   # add filter to query if specified
-    query["query"]["bool"].update({"filter": {"term": filter} })
+  # if filter is not None and filter != "" and filter != {}:   # add filter to query if specified
+  #   query["query"]["bool"].update({"filter": {"term": filter} })
 
   if not queryAdded:  # If no query features are specified, return all cases up to topk
     query["query"]["bool"]["should"].append(retrieve.MatchAll())

--- a/api/others/project.py
+++ b/api/others/project.py
@@ -88,7 +88,9 @@ def getMappingFrag(attrType, simMetric):
                     }
             }
         }
-    elif attrType == "String" and (simMetric == "Equal" or simMetric == "EqualIgnoreCase" or simMetric == "Array"):
+    elif simMetric == "Jaccard":
+        res['type'] = "keyword"
+    elif attrType == "String" and (simMetric == "Equal" or simMetric == "EqualIgnoreCase"):
         res['type'] = "keyword"
     elif attrType == "String":
         res['type'] = "text"

--- a/api/others/utility.py
+++ b/api/others/utility.py
@@ -30,54 +30,54 @@ def createOrUpdateGlobalConfig(es, config_db="config", globalConfig=None):
   config['attributeOptions'] = []
   config['attributeOptions'].append({'type': 'String',
                                      'similarityTypes': ['Equal', 'EqualIgnoreCase', 'BM25', 'Semantic USE', 'Semantic SBERT', 'None'], 
-                                     'reuseStrategy': ['Best Match'],
+                                     'reuseStrategy': ['NN value'],
                                      'filterOptions': ['None', '=']
                                      })
   config['attributeOptions'].append({'type': 'Integer',
                                      'similarityTypes': ['Equal', 'Nearest Number', 'McSherry More', 'McSherry Less',
                                                          'INRECA More', 'INRECA Less', 'Interval', 'None'],
-                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median', 'Mode'],
+                                     'reuseStrategy': ['NN value', 'Maximum', 'Minimum', 'Mean', 'Median', 'Mode'],
                                      'filterOptions': ['None', '=', '>', '>=', '<', '<=']
                                      })
   config['attributeOptions'].append({'type': 'Float',
                                      'similarityTypes': ['Equal', 'Nearest Number', 'McSherry More', 'McSherry Less',
                                                          'INRECA More', 'INRECA Less', 'Interval', 'None'],
-                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median'],
+                                     'reuseStrategy': ['NN value', 'Maximum', 'Minimum', 'Mean', 'Median'],
                                      'filterOptions': ['None', '=', '>', '>=', '<', '<=']
                                      })
   config['attributeOptions'].append({'type': 'Categorical',
                                      'similarityTypes': ['Equal', 'EqualIgnoreCase', 'Table', 'EnumDistance', 'None'],
-                                     'reuseStrategy': ['Best Match'],
+                                     'reuseStrategy': ['NN value'],
                                      'filterOptions': ['None', '=']
                                      })
   config['attributeOptions'].append({'type': 'Boolean',
                                      'similarityTypes': ['Equal', 'None'],
-                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median'],
+                                     'reuseStrategy': ['NN value', 'Majority', 'Minority'],
                                      'filterOptions': ['None', '=']
                                      })
   config['attributeOptions'].append({'type': 'Date',
                                      'similarityTypes': ['Nearest Date', 'None'], 
-                                     'reuseStrategy': ['Best Match'],
+                                     'reuseStrategy': ['NN value'],
                                      'filterOptions': ['None', '=', '>', '>=', '<', '<=']
                                      })
   config['attributeOptions'].append({'type': 'Array',
                                      'similarityTypes': ['Jaccard', 'Array SBERT', 'Query Intersection', 'None'],
-                                     'reuseStrategy': ['Best Match'],
+                                     'reuseStrategy': ['NN value'],
                                      'filterOptions': ['None']
                                      })
   config['attributeOptions'].append({'type': 'Location',
                                      'similarityTypes': ['Nearest Location', 'None'], 
-                                     'reuseStrategy': ['Best Match'],
+                                     'reuseStrategy': ['NN value'],
                                      'filterOptions': ['None']
                                      })
   config['attributeOptions'].append({'type': 'Ontology Concept',
                                      'similarityTypes': ['Path-based', 'Feature-based', 'None'], 
-                                     'reuseStrategy': ['Best Match'],
+                                     'reuseStrategy': ['NN value'],
                                      'filterOptions': ['None', '=']
                                      })
   config['attributeOptions'].append({'type': 'Object', 
                                      'similarityTypes': ['None'],
-                                     'reuseStrategy': ['Best Match'],
+                                     'reuseStrategy': ['NN value'],
                                      'filterOptions': ['None']
                                      })
   # print(config)

--- a/api/others/utility.py
+++ b/api/others/utility.py
@@ -28,29 +28,53 @@ def createOrUpdateGlobalConfig(es, config_db="config", globalConfig=None):
   # print("Adding global configuration to ES.")
   config = {}
   config['attributeOptions'] = []
-  config['attributeOptions'].append(
-    {'type': 'String', 'similarityTypes': ['Equal', 'EqualIgnoreCase', 'BM25', 'Semantic USE', 'Semantic SBERT','Array', 'Array SBERT', 'None'],
-     'reuseStrategy': ['Best Match']})
+  config['attributeOptions'].append({'type': 'String',
+                                     'similarityTypes': ['Equal', 'EqualIgnoreCase', 'BM25', 'Semantic USE', 'Semantic SBERT', 'Array', 'Array SBERT', 'None'], 
+                                     'reuseStrategy': ['Best Match'],
+                                     'filterOptions': ['None', '=']
+                                     })
   config['attributeOptions'].append({'type': 'Integer',
                                      'similarityTypes': ['Equal', 'Nearest Number', 'McSherry More', 'McSherry Less',
                                                          'INRECA More', 'INRECA Less', 'Interval', 'Array', 'None'],
-                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median', 'Mode']})
+                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median', 'Mode'],
+                                     'filterOptions': ['None', '=', '>', '>=', '<', '<=']
+                                     })
   config['attributeOptions'].append({'type': 'Float',
                                      'similarityTypes': ['Equal', 'Nearest Number', 'McSherry More', 'McSherry Less',
-                                                         'INRECA More', 'INRECA Less', 'Interval', 'Array','None'],
-                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median']})
+                                                         'INRECA More', 'INRECA Less', 'Interval', 'Array', 'None'],
+                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median'],
+                                     'filterOptions': ['None', '=', '>', '>=', '<', '<=']
+                                     })
   config['attributeOptions'].append({'type': 'Categorical',
                                      'similarityTypes': ['Equal', 'EqualIgnoreCase', 'Table', 'EnumDistance', 'Query Intersection', 'None'],
-                                     'reuseStrategy': ['Best Match']})
-  config['attributeOptions'].append({'type': 'Boolean', 'similarityTypes': ['Equal', 'None'],
-                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median']})
-  config['attributeOptions'].append(
-    {'type': 'Date', 'similarityTypes': ['Nearest Date', 'None'], 'reuseStrategy': ['Best Match']})
-  config['attributeOptions'].append(
-    {'type': 'Location', 'similarityTypes': ['Nearest Location', 'None'], 'reuseStrategy': ['Best Match']})
-  config['attributeOptions'].append(
-    {'type': 'Ontology Concept', 'similarityTypes': ['Path-based', 'Feature-based', 'None'], 'reuseStrategy': ['Best Match']})
-  config['attributeOptions'].append({'type': 'Object', 'similarityTypes': ['None'], 'reuseStrategy': ['Best Match']})
+                                     'reuseStrategy': ['Best Match'],
+                                     'filterOptions': ['None', '=']
+                                     })
+  config['attributeOptions'].append({'type': 'Boolean',
+                                     'similarityTypes': ['Equal', 'None'],
+                                     'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median'],
+                                     'filterOptions': ['None', '=']
+                                     })
+  config['attributeOptions'].append({'type': 'Date',
+                                     'similarityTypes': ['Nearest Date', 'None'], 
+                                     'reuseStrategy': ['Best Match'],
+                                     'filterOptions': ['None', '=', '>', '>=', '<', '<=']
+                                     })
+  config['attributeOptions'].append({'type': 'Location',
+                                     'similarityTypes': ['Nearest Location', 'None'], 
+                                     'reuseStrategy': ['Best Match'],
+                                     'filterOptions': ['None']
+                                     })
+  config['attributeOptions'].append({'type': 'Ontology Concept',
+                                     'similarityTypes': ['Path-based', 'Feature-based', 'None'], 
+                                     'reuseStrategy': ['Best Match'],
+                                     'filterOptions': ['None', '=']
+                                     })
+  config['attributeOptions'].append({'type': 'Object', 
+                                     'similarityTypes': ['None'],
+                                     'reuseStrategy': ['Best Match'],
+                                     'filterOptions': ['None']
+                                     })
   # print(config)
   time.sleep(0.2) # wait before index create finishes 
   res2 = es.index(index=config_db, body=config)

--- a/api/others/utility.py
+++ b/api/others/utility.py
@@ -29,24 +29,24 @@ def createOrUpdateGlobalConfig(es, config_db="config", globalConfig=None):
   config = {}
   config['attributeOptions'] = []
   config['attributeOptions'].append({'type': 'String',
-                                     'similarityTypes': ['Equal', 'EqualIgnoreCase', 'BM25', 'Semantic USE', 'Semantic SBERT', 'Array', 'Array SBERT', 'None'], 
+                                     'similarityTypes': ['Equal', 'EqualIgnoreCase', 'BM25', 'Semantic USE', 'Semantic SBERT', 'None'], 
                                      'reuseStrategy': ['Best Match'],
                                      'filterOptions': ['None', '=']
                                      })
   config['attributeOptions'].append({'type': 'Integer',
                                      'similarityTypes': ['Equal', 'Nearest Number', 'McSherry More', 'McSherry Less',
-                                                         'INRECA More', 'INRECA Less', 'Interval', 'Array', 'None'],
+                                                         'INRECA More', 'INRECA Less', 'Interval', 'None'],
                                      'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median', 'Mode'],
                                      'filterOptions': ['None', '=', '>', '>=', '<', '<=']
                                      })
   config['attributeOptions'].append({'type': 'Float',
                                      'similarityTypes': ['Equal', 'Nearest Number', 'McSherry More', 'McSherry Less',
-                                                         'INRECA More', 'INRECA Less', 'Interval', 'Array', 'None'],
+                                                         'INRECA More', 'INRECA Less', 'Interval', 'None'],
                                      'reuseStrategy': ['Best Match', 'Maximum', 'Minimum', 'Mean', 'Median'],
                                      'filterOptions': ['None', '=', '>', '>=', '<', '<=']
                                      })
   config['attributeOptions'].append({'type': 'Categorical',
-                                     'similarityTypes': ['Equal', 'EqualIgnoreCase', 'Table', 'EnumDistance', 'Query Intersection', 'None'],
+                                     'similarityTypes': ['Equal', 'EqualIgnoreCase', 'Table', 'EnumDistance', 'None'],
                                      'reuseStrategy': ['Best Match'],
                                      'filterOptions': ['None', '=']
                                      })
@@ -59,6 +59,11 @@ def createOrUpdateGlobalConfig(es, config_db="config", globalConfig=None):
                                      'similarityTypes': ['Nearest Date', 'None'], 
                                      'reuseStrategy': ['Best Match'],
                                      'filterOptions': ['None', '=', '>', '>=', '<', '<=']
+                                     })
+  config['attributeOptions'].append({'type': 'Array',
+                                     'similarityTypes': ['Jaccard', 'Array SBERT', 'Query Intersection', 'None'],
+                                     'reuseStrategy': ['Best Match'],
+                                     'filterOptions': ['None']
                                      })
   config['attributeOptions'].append({'type': 'Location',
                                      'similarityTypes': ['Nearest Location', 'None'], 

--- a/dashboard/app/app.js
+++ b/dashboard/app/app.js
@@ -10,6 +10,7 @@ angular.module('cloodApp', [
   'ngTouch',
   'ui.bootstrap',
   'toaster',
+  'cloodApp.global_config',
   'cloodApp.projects',
   'cloodApp.config',
   'cloodApp.cbr',
@@ -52,6 +53,15 @@ run(['$rootScope', '$http', 'ENV_CONST', function($rootScope, $http, ENV_CONST){
     $http.get(ENV_CONST.base_api_url + "/config", {headers: {"Authorization":$rootScope.checkauth()}}).then(function(res) {
       if (typeof res.data.attributeOptions != 'undefined'){
         $rootScope.globalConfig = res.data; // should allow update in settings
+      }
+    }, function(err) {
+      console.log(err.data);
+    });
+  };
+  $rootScope.createGlobalConfig = function() {  // re-creates global config
+    $http.get(ENV_CONST.base_api_url + "/config/create", {headers: {"Authorization":$rootScope.checkauth()}}).then(function(res) {
+      if (typeof res.data.attributeOptions != 'undefined'){
+        $rootScope.globalConfig = res.data;
       }
     }, function(err) {
       console.log(err.data);

--- a/dashboard/app/cbr/cbr.js
+++ b/dashboard/app/cbr/cbr.js
@@ -32,7 +32,20 @@ angular.module('cloodApp.cbr', [])
   $stateProvider.state(cbrReviseState);
   $stateProvider.state(cbrRetainState);
 }])
-
+.filter('displaySnippet', [function(){  // display snippets for long texts
+  return function(input, scope, num){  // num - max no. of characters to display
+    // if (typeof input != 'undefined' && scope.getDataType(input) == 'string' && scope.stringIsUrl(input)) { // returns the last part of a string if URL
+    //   if (input.lastIndexOf("#") != -1)
+    //     return input.substr(input.lastIndexOf("#") + 1);
+    //   if (input.lastIndexOf("/") != -1)
+    //     return input.substr(input.lastIndexOf("/") + 1);
+    // }
+    if (typeof input != 'undefined' && scope.getDataType(input) == 'string' && input.length > num) {
+      return input.substr(0, num) + '...'
+    }
+    return input;
+  }
+}])
 .controller('CBRCtrl', ['$scope', '$http', '$state', 'ENV_CONST', '$uibModal', function($scope, $http, $state, ENV_CONST, $uibModal ) {
   $scope.datenow = new Date();  // current date for any date field selection
   $scope.menu.active = $scope.menu.items[2]; // ui active menu tag
@@ -66,7 +79,7 @@ angular.module('cloodApp.cbr', [])
   $scope.retrieveCases = function() {
     $scope.requests.current.project = angular.copy($scope.selected);
     // Check if the type is Array
-    console.log("Current ", $scope.requests.current); // array attributes: name, value, weight, unknown, strategy (if unknown
+    // console.log("Current ", $scope.requests.current); // array attributes: name, value, weight, unknown, strategy (if unknown
     angular.forEach($scope.requests.current.data, function(value, key) {
       if ((value.similarity == "Array" || value.similarity == "Array SBERT") && value.value != "" && value.value != null) {
         value.value = value.value.split(",");
@@ -78,7 +91,7 @@ angular.module('cloodApp.cbr', [])
       }
     });
 
-    console.log("Current ", $scope.requests.current); // array attributes: name, value, weight, unknown, strategy (if unknown)
+    // console.log("Current ", $scope.requests.current); // array attributes: name, value, weight, unknown, strategy (if unknown)
     $http.post(ENV_CONST.base_api_url + '/retrieve', $scope.requests.current, {headers:{"Authorization":$scope.auth.token}}).then(function(res) {
       $scope.requests.response = res.data;
       console.log($scope.requests.response)
@@ -182,6 +195,28 @@ angular.module('cloodApp.cbr', [])
 
     $scope.pop("success", null, "Downloading cases as CSV");
   };
+
+  // Check if data type can be used as a filter
+  $scope.getIsFilterOptions = function(type) {
+    if (typeof type != 'undefined' && type != null) {
+      var res = $scope.globalConfig.attributeOptions.find(obj => {
+        return obj.type === type
+      });
+      return res.filterOptions;
+    }
+    return false;
+  };
+
+  // checks if string is a url
+  $scope.stringIsUrl = function(str) {
+    let url;
+    try {
+      url = new URL(str);
+    } catch (_) {
+      return false;
+    }
+    return url.protocol === "http:" || url.protocol === "https:";
+  }
 
   $scope.plotTest = function() {
     var attributes = [];

--- a/dashboard/app/cbr/cbr.js
+++ b/dashboard/app/cbr/cbr.js
@@ -81,8 +81,8 @@ angular.module('cloodApp.cbr', [])
     // Check if the type is Array
     // console.log("Current ", $scope.requests.current); // array attributes: name, value, weight, unknown, strategy (if unknown
     angular.forEach($scope.requests.current.data, function(value, key) {
-      if ((value.similarity == "Array" || value.similarity == "Array SBERT") && value.value != "" && value.value != null) {
-        value.value = value.value.split(",");
+      if (value.type == "Array" && value.value != "" && value.value != null) {
+        value.value = value.value.split(",").map(item=>item.trim());
         if(value.type == "Integer") {
           value.value = value.value.map(function (el) { return parseInt(el); });
         } else if (value.type == "Float") {
@@ -131,14 +131,14 @@ angular.module('cloodApp.cbr', [])
 
     // Convert csv input to array
     angular.forEach(newCase.project.attributes, function(value, key) {
-      if ((value.similarity == "Array"  || value.similarity == "Array SBERT") && newCase.data[value.name] != null && newCase.data[value.name] != "") {
-        newCase.data[value.name] = newCase.data[value.name].split(",");
+      if ((value.type == "Array") && newCase.data[value.name] != null && newCase.data[value.name] != "") {
+        newCase.data[value.name] = newCase.data[value.name].split(",").map(item=>item.trim());
         if (value.type == "Integer") {
           newCase.data[value.name] = newCase.data[value.name].map(function (el) { return parseInt(el); });
         } else if (value.type == "Float") {
           newCase.data[value.name] = newCase.data[value.name].map(function (el) { return parseFloat(el); });
         }
-      console.log("newCase",newCase);
+      // console.log("newCase",newCase);
       }
     });
 

--- a/dashboard/app/cbr/views/retrieve.html
+++ b/dashboard/app/cbr/views/retrieve.html
@@ -14,11 +14,12 @@
               <table class="table table-striped table-bordered" width="100%" cellspacing="0">
                 <thead>
                   <tr>
-                    <th>Attribute (Type)</th>
-                    <th>Attribute value</th>
-                    <th>Weight</th>
-                    <th>Solution</th>
-                    <th>Retrieve<br> strategy</th>
+                    <th style="width:20%">Attribute (Type)</th>
+                    <th style="width:30%">Attribute value</th>
+                    <th style="width:10%">Weight</th>
+                    <th style="width:20%">Filter</th>
+                    <th style="width:10%">Solution</th>
+                    <th style="width:10%">Reuse<br> strategy</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -67,8 +68,20 @@
                         <input type="number" class="form-control" ng-model="requests.current.data[$index].weight" min="0" max="10">
                       </div>
                     </td>
+                    <!-- Filter? (filter out cases which do not match, but they will not affect the score for matching cases) -->
+                    <td  style="text-align:center;">
+                      <div class="form-group" ng-init="requests.current.data[$index].filterTerm = getIsFilterOptions(field.type)[0]">
+                        <select class="form-control" ng-options="filterOpt for filterOpt in getIsFilterOptions(field.type)" ng-model="requests.current.data[$index].filterTerm" value="{{filterOpt}}">
+                          {{ filterOpt }}
+                        </select>
+                        <!-- Filter is range type -->
+                        <div ng-if="(requests.current.data[$index].filterTerm!=='None' && requests.current.data[$index].filterTerm!=='=')" class="form-group">
+                          <input type="text" class="form-control" ng-model="requests.current.data[$index].filterValue" placeholder="Filter value">
+                        </div>
+                      </div>
+                    </td>
                     <!-- Unknown or Determine (False=Problem/Known OR True=Solution/Unknown) -->
-                    <td  style="text-align:center;" ng-init="requests.current.data[$index].unknown = false">
+                    <td style="text-align:center;" ng-init="requests.current.data[$index].unknown = false">
                       <div class="form-group">
                         <input class="form-check-input" type="checkbox" ng-model="requests.current.data[$index].unknown">
                       </div>

--- a/dashboard/app/cbr/views/retrieve.html
+++ b/dashboard/app/cbr/views/retrieve.html
@@ -26,20 +26,18 @@
                   <tr ng-repeat="field in selected.attributes">
                     <!-- Field -->
                     <td ng-init="requests.current.data[$index].name = field.name">
-                      {{ field.name }} <span ng-init="requests.current.data[$index].type = field.type">({{ field.type }}){{ field.similarity == "Array" ? '(Array)' : '' }}</span>
+                      {{ field.name }} <span ng-init="requests.current.data[$index].type = field.type">({{ field.type }})</span>
+                      <i class="fas fa-info-circle" ng-if="field.type == 'Array'" data-toggle="tooltip" data-placement="right" title="Use commas to separate multiple values."></i>
                     </td>
                     <!-- Value -->
                     <td ng-init="requests.current.data[$index].similarity = field.similarity">
                       <!-- String type -->
-                      <div ng-if="(field.type=='String' || field.type=='Ontology Concept')  && field.similarity != 'Array' && field.similarity != 'Array SBERT'" class="form-group">
+                      <div ng-if="(field.type=='String' || field.type=='Ontology Concept')" class="form-group">
                         <input type="text" class="form-control" ng-model="requests.current.data[$index].value" placeholder="{{ field.name }}">
                       </div>
                       <!-- Numeric type -->
-                      <div ng-if="(field.type=='Integer' || field.type=='Float') && field.similarity != 'Array' && field.similarity != 'Array SBERT'" class="form-group">
+                      <div ng-if="(field.type=='Integer' || field.type=='Float')" class="form-group">
                         <input type="number" class="form-control" ng-model="requests.current.data[$index].value" placeholder="{{ field.name }}">
-                      </div>
-                      <div ng-if="field.similarity == 'Array' || field.similarity == 'Array SBERT'" class="form-group">
-                        <input class="form-control" ng-model="requests.current.data[$index].value" placeholder="{{ field.name }}">
                       </div>
                       <!-- Boolean type -->
                       <div ng-if="field.type=='Boolean'" class="form-group">
@@ -54,11 +52,11 @@
                         <input type="text" class="form-control" ng-model="requests.current.data[$index].value" placeholder="{{ field.name }} as 'lat,lon'">
                       </div>
                       <!-- Categorical type -->
-                      <div ng-if="field.type=='Categorical' && field.similarity!='Query Intersection'" class="form-group">
+                      <div ng-if="field.type=='Categorical'" class="form-group">
                         <select class="form-control" ng-model="requests.current.data[$index].value" ng-options="val as val for val in field.options.values" placeholder="{{ field.name }}"></select>
                       </div>
-
-                      <div ng-if="field.similarity=='Query Intersection'" class="form-group">
+                      <!-- Array type -->
+                      <div ng-if="field.type=='Array'" class="form-group">
                         <textarea class="form-control" ng-model="requests.current.data[$index].value" ng-list rows="1" placeholder="{{ field.name }}"></textarea>
                       </div>
                     </td>

--- a/dashboard/app/cbr/views/reuse.html
+++ b/dashboard/app/cbr/views/reuse.html
@@ -14,16 +14,10 @@
   </button>
 </div>
 
-<div class="row" ng-if="requests.current.explanation && requests.response.bestK.length>0">
-  <h4 align="center">Parallel Coordinate Plot of Top 5 Cases</h4>
-  <div id="plotly-graph" ng-init="plotTest()"><p style="color: red;margin: auto;" ng-if="requests.response.bestK[0].match_explanation.length==0">Query against specific case attributes to see a plot of local similarities</p></div>
-  
-</div>
-
 <div class="row">
   <!-- Display recommended solution -->
   <div class="row" ng-show="objOrArrayHasContent(requests.response.recommended)">
-    <h4 align="center">Recommendation</h4>
+    <h4 align="center">Recommendation (with chosen reuse strategies)</h4>
     <div class="col-lg-12">
       <div class="p-5">
         <form id="reviseForm">
@@ -38,7 +32,7 @@
               <tbody>
                 <tr>
                   <td ng-repeat="(key, value) in requests.response.recommended">
-                    <span ng-if=" getDataType(value)!='object' ">{{ value }}</span>
+                    <span ng-if=" getDataType(value)!='object' ">{{ value | displaySnippet:this:70 }}</span>
                     <code ng-if=" getDataType(value)=='object' ">
                       <pre>{{ value | json }}</pre>
                     </code>
@@ -64,6 +58,12 @@
   </div>
 </div>
 
+<div class="row" ng-if="requests.current.explanation && requests.response.bestK.length>0">
+  <h4 align="center">Parallel Coordinate Plot of Nearest Cases (5 max)</h4>
+  <div id="plotly-graph" ng-init="plotTest()"><p style="color: red;margin: auto;" ng-if="requests.response.bestK[0].match_explanation.length==0">Query against specific case attributes to see a plot of local similarities</p></div>
+  
+</div>
+
 <div class="row">
   <!-- Display most similar cases -->
   <div class="row" ng-show="objOrArrayHasContent(requests.response.bestK)">
@@ -84,7 +84,7 @@
               <tbody>
                 <tr ng-repeat="entry in requests.response.bestK">
                   <td ng-repeat="attrib in selected.attributes" ng-if="entry">
-                    <span ng-if=" getDataType(entry[attrib.name])!='object' ">{{ getDataType(entry[attrib.name]) === 'string' ? entry[attrib.name].substr(0, 50) : entry[attrib.name] }}{{ entry[attrib.name].length > 50 ? '...' : ''}}</span>
+                    <span ng-if=" getDataType(entry[attrib.name])!='object' ">{{ entry[attrib.name] | displaySnippet:this:70 }}</span>
                     <code ng-if=" getDataType(entry[attrib.name])=='object' ">
                       <pre>{{ entry[attrib.name] | json }}</pre>
                     </code>

--- a/dashboard/app/config/config.js
+++ b/dashboard/app/config/config.js
@@ -530,7 +530,7 @@ angular.module('cloodApp.config', [])
     $http.post(ENV_CONST.base_api_url + '/retain', $scope.newCase, {headers:{"Authorization":$scope.auth.token}}).then(function(res) {
       console.log(res.data);
       $scope.pop("success", null, "New case added.");
-      $scope.newCase = {'data':[], 'project':null};
+      $scope.newCase = {'data':{}, 'project':{}};
     }).catch(function(err) {
       console.log(err);
       $scope.pop("error", null, "Case added was not added. Duplicate cases are rejected when not allowing duplicates.");
@@ -625,8 +625,13 @@ angular.module('cloodApp.config', [])
 
   $scope.save = function() {
     console.log($scope.sim_grid);
+    console.log($scope.data.options);
     //{...}
     if ($scope.data.options.values.length > 0) { // if there are values specified
+      if (typeof $scope.data.options.sim_grid == 'undefined') {
+        console.log('sim_grid is undefined');
+        $scope.data.options.sim_grid = {}
+      }
       // Add the new sim values from temp copy.
       // Attribute values are used as keys to ensure that sim values are not kept for remove attribute values.
       angular.forEach($scope.data.options.values, function(value1){

--- a/dashboard/app/config/config.js
+++ b/dashboard/app/config/config.js
@@ -516,14 +516,14 @@ angular.module('cloodApp.config', [])
     
     // Convert csv input to array
     angular.forEach($scope.newCase.project.attributes, function(value, key) {
-      if ((value.similarity == "Array" || value.similarity == "Array SBERT") && $scope.newCase.data[value.name] != null && $scope.newCase.data[value.name] != "") {
-        $scope.newCase.data[value.name] = $scope.newCase.data[value.name].split(",");
+      if ((value.type == "Array") && $scope.newCase.data[value.name] != null && $scope.newCase.data[value.name] != "") {
+        $scope.newCase.data[value.name] = $scope.newCase.data[value.name].split(",").map(item=>item.trim());
         if (value.type == "Integer") {
           $scope.newCase.data[value.name] = $scope.newCase.data[value.name].map(function (el) { return parseInt(el); });
         } else if (value.type == "Float") {
           $scope.newCase.data[value.name] = $scope.newCase.data[value.name].map(function (el) { return parseFloat(el); });
         }
-      console.log("newCase",$scope.newCase);
+      // console.log("newCase",$scope.newCase);
       }
     });
 

--- a/dashboard/app/config/views/add_case.html
+++ b/dashboard/app/config/views/add_case.html
@@ -20,8 +20,8 @@
                     <tr ng-repeat="attribute in selected.attributes">
                         <td>{{ attribute.name }}</td>
                         <td>
-                            {{ attribute.type }}{{ (attribute.similarity == "Array" || attribute.similarity == "Array SBERT") ? '(Array)' : '' }}
-                            <i class="fas fa-info-circle" ng-if="attribute.similarity == 'Array' || attribute.similarity == 'Array SBERT'" data-toggle="tooltip" data-placement="right" title="Array values are created by seperating values with commas."></i>
+                            {{ attribute.type }}
+                            <i class="fas fa-info-circle" ng-if="attribute.type == 'Array'" data-toggle="tooltip" data-placement="right" title="Array values are created by seperating values with commas."></i>
                         </td>
                         <td>
                             <input type="text" class="form-control" ng-model="newCase['data'][attribute.name]" ng-disabled="!selected.attributes.length>0">

--- a/dashboard/app/config/views/modalviews/similarity_list.html
+++ b/dashboard/app/config/views/modalviews/similarity_list.html
@@ -1,9 +1,9 @@
 <div class="modal-header">
-    <h3 class="modal-title" id="modal-title">List of All Similarities</h3>
+    <h3 class="modal-title" id="modal-title">List of Similarity Metrics</h3>
 </div>
 <div class="modal-body" id="modal-body">
-    <p class="lead">Array (Jaccard)</p>
-    <p><b>Suitable data types: </b>String, Integer, Float</p>
+    <p class="lead">Jaccard</p>
+    <p><b>Suitable data types: </b>Arrays of String, Integer, Float</p>
     <p><b>Description: </b>Uses the Jaccard similarity metric to compare two arrays. Returns a score equal to the intersection of the two arrays over
         the union of the two arrays. Intersection is the number of elements in both arrays, union is the number of elements in either array.
          Returns a score between 0 and 1, with 1 being an exact match. 
@@ -119,7 +119,7 @@
         Calculates the similarity between two sets of categorical values. 
         The similarity score is calculated by dividing the number of values in the intersection of the two sets by the length of the query set.
     </p>
-    <p><b>Formula: </b><code>"|a & b| / |a|"</code>
+    <p><b>Formula: </b><code>"|a ∩ b| / |a|"</code>
         <br/><i>where "a" is the query value and "b" is the case value</i>
     </p>
 </div>

--- a/dashboard/app/global_config/global_config.html
+++ b/dashboard/app/global_config/global_config.html
@@ -19,6 +19,7 @@
             <th>Data Type</th>
             <th>Similarity Metrics</th>
             <th>Reuse Strategies</th>
+            <th>Filter Options</th>
           </tr>
         </thead>
         <tbody>
@@ -39,7 +40,12 @@
                 <li ng-repeat="reuseOpt in opt.reuseStrategy">{{ reuseOpt }}</li>
               </ul>
             </td>
-            
+            <!-- filterable -->
+            <td>
+              <ul>
+                <li ng-repeat="filterOpt in opt.filterOptions">{{ filterOpt }}</li>
+              </ul>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/dashboard/app/global_config/global_config.html
+++ b/dashboard/app/global_config/global_config.html
@@ -1,0 +1,53 @@
+<div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+
+  <h1 class="h4 text-gray-900 mb-4">System Settings</h1>
+
+  <p>The CloodCBR Configuration Taxonomy specifies the data types and their corresponding similarity types and reuse strategies. 
+    Use the <em></b>Update Settings</em> button if there are changes to CloodCBR configuration that are not visible on the dashboard.</p>
+
+  <div class="row">
+    <!-- <div>
+      <code ng-if="globalConfig">
+        <pre>{{ globalConfig | json }}</pre>
+      </code>
+    </div> -->
+
+    <div class="table-responsive">
+      <table class="table table-striped table-bordered" width="100%" cellspacing="0">
+        <thead>
+          <tr>
+            <th>Data Type</th>
+            <th>Similarity Metrics</th>
+            <th>Reuse Strategies</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr ng-repeat="opt in globalConfig.attributeOptions">
+            <!-- type -->
+            <td>
+              {{ opt.type }}
+            </td>
+            <!-- similarityTypes -->
+            <td>
+              <ul>
+                <li ng-repeat="similarityOpt in opt.similarityTypes">{{ similarityOpt }}</li>
+              </ul>
+            </td>
+            <!-- reuseStrategy -->
+            <td>
+              <ul>
+                <li ng-repeat="reuseOpt in opt.reuseStrategy">{{ reuseOpt }}</li>
+              </ul>
+            </td>
+            
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <button type="button" name="button" class="btn btn-block btn-primary" ng-click="updateGlobalConfig()">
+    Update Settings
+  </button>
+
+</div>

--- a/dashboard/app/global_config/global_config.html
+++ b/dashboard/app/global_config/global_config.html
@@ -3,7 +3,7 @@
   <h1 class="h4 text-gray-900 mb-4">System Settings</h1>
 
   <p>The CloodCBR Configuration Taxonomy specifies the data types and their corresponding similarity types and reuse strategies. 
-    Use the <em></b>Update Settings</em> button if there are changes to CloodCBR configuration that are not visible on the dashboard.</p>
+    Use the <b>Update Settings</b> button if there are changes to CloodCBR configuration that are not visible on the dashboard. Refresh the page if you still cannot see the changes after clicking Update Settings.</p>
 
   <div class="row">
     <!-- <div>

--- a/dashboard/app/global_config/global_config.js
+++ b/dashboard/app/global_config/global_config.js
@@ -1,0 +1,28 @@
+'use strict';
+
+angular.module('cloodApp.global_config', [])
+.config(['$stateProvider', function($stateProvider) {
+  var globalConfigState = {
+    name: 'global_config',
+    url: '/global_config',
+    templateUrl: 'global_config/global_config.html',
+    controller: 'GlobalConfigCtrl'
+  };
+  
+  $stateProvider.state(globalConfigState);
+}])
+
+.controller('GlobalConfigCtrl', ['$scope', 'ENV_CONST', '$log', function($scope, ENV_CONST, $log) {
+  
+  if (typeof ENV_CONST.base_api_url == 'undefined' || ENV_CONST.base_api_url == '') {
+    $scope.pop("warn", null, "The root API to the serverless functions is not set. You can set this up in env.js");
+  }
+
+  // Updates the global config to reflect changes in clood service
+  $scope.updateGlobalConfig = function() {
+    $scope.createGlobalConfig(); // create config
+    $scope.getGlobalConfig(); // get config
+    location.reload();  // refresh page
+  };
+  
+}]);

--- a/dashboard/app/index.html
+++ b/dashboard/app/index.html
@@ -43,6 +43,7 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{auth.user}} <span class="caret"></span></a>
             <ul class="dropdown-menu">
+              <li><a href="#/global_config">Settings</a></li>
               <li><a href="#" ng-click="logout()">Logout</a></li>
             </ul>
           </li>
@@ -122,6 +123,7 @@
 
   <script src="app.js"></script>
   <script src="env.js"></script>
+  <script src="global_config/global_config.js"></script>
   <script src="projects/projects.js"></script>
   <script src="config/config.js"></script>
   <script src="cbr/cbr.js"></script>


### PR DESCRIPTION
- Refine filters: can specify filter per attribute with support for term and range filters.
- Add Array data type.
- Display / refresh global configuration on the dashboard.
- Update reuse strategies for Boolean type.
- Fix bug with adding consecutive new cases through dashboard without page refresh 
- Support new case dict and str data types
- Other minor fixes (e.g. trim trailing spaces in array attribute types, rename 'Array' similarity to 'Jaccard'.